### PR TITLE
cleanup: remove dead amount_spent column and short-circuit taste profile

### DIFF
--- a/backend/controllers/tasteProfileCtrl.js
+++ b/backend/controllers/tasteProfileCtrl.js
@@ -6,6 +6,9 @@ const tasteProfileCtrl = async (req, res) => {
   const userId = req.user.userId;
   try {
     const ratedFavorites = await favoritesRepository.getRatedFavorites(userId);
+    if (!ratedFavorites.length) {
+      return sendSuccess(res, { insight: null, ratingCount: 0 });
+    }
     const insight = await generateInsightFromRatings(ratedFavorites);
     sendSuccess(res, { insight, ratingCount: ratedFavorites.length });
   } catch (err) {

--- a/backend/repositories/favoritesRepository.js
+++ b/backend/repositories/favoritesRepository.js
@@ -16,7 +16,7 @@ const favoritesRepository = {
 
   getFavorites: async (userId, backendUrl) => {
     const rows = await queryDB(
-      `SELECT r.*, uf.note, uf.status, uf.rating, uf.amount_spent
+      `SELECT r.*, uf.note, uf.status, uf.rating
        FROM restaurants r
        INNER JOIN user_favorites uf ON r.id = uf.restaurant_id
        WHERE uf.user_id = ?

--- a/backend/utils/restaurantFormatter.js
+++ b/backend/utils/restaurantFormatter.js
@@ -98,7 +98,6 @@ export const normalizeDatabasePlace = (rows, backendUrl) =>
     categories: r.category ? [{ alias: r.category, title: r.category }] : [],
     ...(r.note !== undefined && { note: r.note }),
     ...(r.status !== undefined && { status: r.status }),
-    ...(r.amount_spent !== undefined && { amount_spent: r.amount_spent }),
   }));
 
 // Convert Google day (0=Sun) to Yelp day (0=Mon)

--- a/schema.sql
+++ b/schema.sql
@@ -135,7 +135,6 @@ CREATE TABLE `user_favorites` (
   `status` enum('want_to_go','visited') NOT NULL DEFAULT 'want_to_go',
   `note` text,
   `rating` tinyint DEFAULT NULL,
-  `amount_spent` decimal(8,2) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unique_favorite` (`user_id`,`restaurant_id`),
   CONSTRAINT `user_favorites_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
@@ -148,7 +147,6 @@ CREATE TABLE `user_favorites` (
 --   ADD COLUMN IF NOT EXISTS note TEXT NULL,
 --   ADD COLUMN IF NOT EXISTS rating TINYINT NULL,
 --   ADD CONSTRAINT chk_rating CHECK (rating BETWEEN 1 AND 5);
--- ALTER TABLE user_favorites ADD COLUMN IF NOT EXISTS amount_spent DECIMAL(8,2) NULL;
 
 --
 -- Table structure for table `spend_logs`


### PR DESCRIPTION
- Dropped unused amount_spent column from user_favorites since spend tracking is handled via the spend_logs table; the column was selected and propagated through normalizeDatabasePlace but never written to.
- Short-circuited tasteProfileCtrl when the user has zero rated favorites to avoid an unnecessary Groq call on every Profile load.